### PR TITLE
Support reentering playmode when there is no domain reload

### DIFF
--- a/Runtime/Singletons/AutoStartMonoSingleton.cs
+++ b/Runtime/Singletons/AutoStartMonoSingleton.cs
@@ -5,21 +5,18 @@ namespace Juce.Utils.Singletons
     public abstract class AutoStartMonoSingleton<T> : MonoBehaviour where T : MonoBehaviour
     {
         private static T singletonInstance;
-        private static bool created;
 
-        public static bool InstanceWasDestroyed => singletonInstance == null && created;
+        public static bool InstanceWasDestroyed => singletonInstance == null;
 
         public static T Instance
         {
             get
             {
-                if (!created)
+                if (singletonInstance == null)
                 {
                     GameObject newGameObject = new GameObject(typeof(T).Name);
                     DontDestroyOnLoad(newGameObject);
                     singletonInstance = newGameObject.AddComponent<T>();
-
-                    created = true;
                 }
 
                 return singletonInstance;


### PR DESCRIPTION
Instead of checking a bool to see if a singleton still has a valid instance, check for it in memory.

I like JuceTween because it lets me rapidly iterate on tweens without changing code. I also like to use Unity's _new-ish_ [Enter Play Mode](https://docs.unity3d.com/Manual/ConfigurableEnterPlayMode.html) setting. This skips the reloading of the scene and most importantly, the C# domain. This allows for near-instantaneous time to enter into play mode.

When using Juce Tween, it stops playing tweens if you have this setting on. This is because `InstanceWasDestroyed` in `AutoStartMonoSingleton.cs` flag is always set to `true`. This is because of the lack of domain reload, leaving `created` always set to true. Unity objects in memory are destroyed, but value types like bools still live in memory.

Instead, this change makes the actual singleton instance the source of truth to check if the singleton was created.